### PR TITLE
Added hide overlay flag, made input file optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ Curses based livecoding vj environment
 Supports python 2 for now...
 - `git clone https://github.com/capalmer1013/vizcurse.git`
 - `cd vizcurse`
-- `python vizcurse -i example.py`
+- `python vizcurse`
 - modify and save example.py
 - repeat
+
+## Input File
+
+By default, vizcurse will use the provided `example.py` as the input file. To use another file, specify the argument: `-i <file_location>`.
+```
+$ python vizcurse -i mycode.py
+```
+
+## Code Overlay
+
+By default vizcurse will overlay the code from input file. To disable this behavior, specify the `--hide-overlay` flag.
+```bash
+$ python vizcurse --hide-overlay
+```
+

--- a/vizcurse/api.py
+++ b/vizcurse/api.py
@@ -76,7 +76,7 @@ def main(stdscr, limit=0):
 #       REQUIRED = __name__ == 'api'
 #       parser.add_argument('-E', required=REQUIRED)
 parser = argparse.ArgumentParser(description='Live coded visuals in the terminal')
-parser.add_argument('-i', type=str, help='Input file to read (Default: example.py)', default='example.py')
+parser.add_argument('-i', type=str, help='Input file to read.', default='example.py')
 parser.add_argument('--hide-overlay', help='Hide code overlay.', action='store_true')
 args = parser.parse_args()
 

--- a/vizcurse/api.py
+++ b/vizcurse/api.py
@@ -33,6 +33,7 @@ def getColor(y, x):
 def main(stdscr, limit=0):
     def loop():
         global file_contents
+        global HIDE_OVERLAY
         updateFunc()
 
         for i in range(0, curses.COLORS):
@@ -47,9 +48,10 @@ def main(stdscr, limit=0):
                 curses.color_pair(getColor(product[0], product[1]))
             )
         # Draw code block
-        file_content_lines = file_contents.splitlines()
-        for line_y, line_content in enumerate(file_content_lines, start=3):
-            stdscr.addstr(line_y, 0, '{} '.format(line_content))
+        if not HIDE_OVERLAY:
+            file_content_lines = file_contents.splitlines()
+            for line_y, line_content in enumerate(file_content_lines, start=3):
+                stdscr.addstr(line_y, 0, '{} '.format(line_content))
 
         stdscr.refresh()
 
@@ -69,25 +71,21 @@ def main(stdscr, limit=0):
         while True:
             loop()
 
-if __name__ == "api":
-    # parse args
-    parser = argparse.ArgumentParser(description='Live coded visuals in the terminal')
-    parser.add_argument('-i', type=str, nargs=1, help='Input file to read.', required=True)
-    args = parser.parse_args()
+# parse args - none are required and defaults are set so __name__ does not need to be checked
+#   If in the future any args become required, we can do:
+#       REQUIRED = __name__ == 'api'
+#       parser.add_argument('-E', required=REQUIRED)
+parser = argparse.ArgumentParser(description='Live coded visuals in the terminal')
+parser.add_argument('-i', type=str, help='Input file to read (Default: example.py)', default='example.py')
+parser.add_argument('--hide-overlay', help='Hide code overlay.', action='store_true')
+args = parser.parse_args()
 
-    # set vars
-    startTime = time.time()
-    FILE_PATH = args.i[0]  # not sure if there's a right way to do this
-    lastupdateTime = os.path.getmtime(FILE_PATH)
-    current_func = lambda x, y, t: 0
-    file_contents = open(FILE_PATH).read()
-    exec(file_contents)
+# set vars
+FILE_PATH = args.i
+HIDE_OVERLAY = args.hide_overlay
 
-else:
-    # set vars
-    startTime = time.time()
-    FILE_PATH = "example.py"
-    lastupdateTime = os.path.getmtime(FILE_PATH)
-    current_func = lambda x, y, t: 0
-    file_contents = open(FILE_PATH).read()
-    exec(file_contents)
+startTime = time.time()
+lastupdateTime = os.path.getmtime(FILE_PATH)
+current_func = lambda x, y, t: 0
+file_contents = open(FILE_PATH).read()
+exec(file_contents)


### PR DESCRIPTION
## What I did
- Added flag to hide code overlay `--hide-overlay`
  - Also added docs for it
- Made input file optional, by default will use `example.py`
  - Modified docs to reflect this
- Made arg parsing section of code a little cleaner while keeping compatibility with `make profile`
  - I also added some notes in the code if we eventually decide to make some args required
  - I'm open to criticism on this change


## Why I did it
- People gotta hide their code
- Lots of duplicate code where args were being parsed


## Issue #s Addressed
- closes #16 

## How to test it

- [x] Run `python vizcurse`, make sure it uses `example.py` and shows the code overlay
- [x] Make a new file called `test.py`
- [x] Run `python vizcurse -i test.py --hide-overlay` and make sure it uses `test.py` and doesn't show the code overlay
- [x] Run `make profile`, make sure it has the expected behavior